### PR TITLE
add option for token key in login response

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -23,6 +23,7 @@ export default defineNuxtModule<DeepPartial<ModuleOptions>>({
     token: {
       storageKey: 'AUTH_TOKEN',
       provider: 'cookie',
+      responseKey: 'token',
     },
     fetchClientOptions: {
       retryAttempts: false,

--- a/src/runtime/composables/useSanctum.ts
+++ b/src/runtime/composables/useSanctum.ts
@@ -47,7 +47,11 @@ export const useSanctum = <T>() => {
 
     // Handle token or cookie auth
     if (authMode === 'token') {
-      await useTokenStorage(nuxtApp).set(response.token);
+      const { token } = options;
+      const tokenValue = token.responseKey
+        .split('.')
+        .reduce((acc, key) => acc && acc[key], response);
+      await useTokenStorage(nuxtApp).set(tokenValue);
     }
 
     await refreshUser();

--- a/src/runtime/types/ModuleOptions.ts
+++ b/src/runtime/types/ModuleOptions.ts
@@ -35,6 +35,12 @@ export interface ModuleOptions {
     storageKey: string;
 
     /**
+     * The key present the token in the login response.
+     * @default 'token'
+     */
+    responseKey: string;
+
+    /**
      * The storage provider to use for the token.
      * @default 'cookie'
      */


### PR DESCRIPTION
Laravel Resource response generally wrap in the data key.

We're heavily following Resource convention in Laravel, that's why we need to define the token key as "data.token" in the login response.

References: https://laravel.com/docs/11.x/eloquent-resources